### PR TITLE
Use managed dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>sc.fiji</groupId>
         <artifactId>pom-fiji</artifactId>
-        <version>16.1.0</version>
+        <version>21.0.0</version>
         <relativePath />
     </parent>
     <groupId>edu.duke.biology.baughlab</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>net.imagej</groupId>
             <artifactId>ij</artifactId>
-            <version>${imagej1.version}</version>
         </dependency>
         <dependency>
             <groupId>au.com.bytecode</groupId>
             <artifactId>opencsv</artifactId>
-            <version>${opencsv.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -41,7 +39,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,18 +54,15 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>Auto_Threshold</artifactId>
-            <version>${Auto_Threshold.version}</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>Skeletonize3D_</artifactId>
-            <version>${Skeletonize3D.version}</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>AnalyzeSkeleton_</artifactId>
             <!-- 3.0 and greater break WormSizer -->
-            <version>2.0.5</version>
         </dependency>
             
 <!--        <dependency>

--- a/src/main/java/edu/duke/biology/baughlab/wormsize/SkeletonizeWrapper.java
+++ b/src/main/java/edu/duke/biology/baughlab/wormsize/SkeletonizeWrapper.java
@@ -5,12 +5,18 @@
 
 package edu.duke.biology.baughlab.wormsize;
 
+import Skeletonize3D_.Skeletonize3D_;
 import ij.ImagePlus;
-import ij.gui.*;
-import java.util.*;
-import Skeletonize3D_.*;
-import skeleton_analysis.*;
 import ij.process.ImageProcessor;
+
+import java.util.ArrayList;
+
+import skeleton_analysis.AnalyzeSkeleton_;
+import skeleton_analysis.Edge;
+import skeleton_analysis.Graph;
+import skeleton_analysis.Point;
+import skeleton_analysis.SkeletonResult;
+import skeleton_analysis.Vertex;
 
 
 /**

--- a/src/main/java/edu/duke/biology/baughlab/wormsize/SkeletonizeWrapper.java
+++ b/src/main/java/edu/duke/biology/baughlab/wormsize/SkeletonizeWrapper.java
@@ -5,18 +5,18 @@
 
 package edu.duke.biology.baughlab.wormsize;
 
-import Skeletonize3D_.Skeletonize3D_;
 import ij.ImagePlus;
 import ij.process.ImageProcessor;
 
 import java.util.ArrayList;
 
-import skeleton_analysis.AnalyzeSkeleton_;
-import skeleton_analysis.Edge;
-import skeleton_analysis.Graph;
-import skeleton_analysis.Point;
-import skeleton_analysis.SkeletonResult;
-import skeleton_analysis.Vertex;
+import sc.fiji.analyzeSkeleton.AnalyzeSkeleton_;
+import sc.fiji.analyzeSkeleton.Edge;
+import sc.fiji.analyzeSkeleton.Graph;
+import sc.fiji.analyzeSkeleton.Point;
+import sc.fiji.analyzeSkeleton.SkeletonResult;
+import sc.fiji.analyzeSkeleton.Vertex;
+import sc.fiji.skeletonize3D.Skeletonize3D_;
 
 
 /**


### PR DESCRIPTION
... and update SkeletonizeWrapper to use new package names.

This is a follow-up to the discussion in https://github.com/bradtmoore/wormsizer/pull/3.

(There are a number of javadoc warnings remaining, I was building successfully with `mvn -Djavadoc.skip`.)
